### PR TITLE
feat: support go mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+go.sum
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/name5566/leaf
+
+require (
+	github.com/golang/protobuf v1.2.0
+	github.com/gorilla/websocket v1.4.0
+	github.com/kr/pretty v0.1.0 // indirect
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)


### PR DESCRIPTION
我把go mod相关的东西加进去了。github并不能提交合并tag，如果想要正常使用go mod，必须把tag改成`v1.2.0`这种格式，而且最好对以往的旧tag再用`git tag v1.0.0 1.0.0`这种格式加上符合语义化版本的tag.